### PR TITLE
Fix process names

### DIFF
--- a/Sloth.xcodeproj/project.pbxproj
+++ b/Sloth.xcodeproj/project.pbxproj
@@ -138,8 +138,11 @@
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 			);
+			indentWidth = 4;
 			name = Sloth;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;

--- a/source/ProcessUtils.m
+++ b/source/ProcessUtils.m
@@ -91,7 +91,8 @@
     if (GetProcessForPID(pid, &psn) == noErr) {
         CFStringRef procName = NULL;
         if (CopyProcessName(&psn, &procName) == noErr) {
-            return [(__bridge_transfer NSString *)procName copy];
+            NSString *nameStr = CFBridgingRelease(procName);
+            return nameStr.length > 0 ? [nameStr copy] : nil;
         }
     }
     return nil;

--- a/source/ProcessUtils.m
+++ b/source/ProcessUtils.m
@@ -114,7 +114,7 @@
 // This is a limitation with libproc on Mac OS X
 + (NSString *)procNameForPID:(pid_t)pid {
     char name[1024];
-    if (proc_name(pid, name, sizeof(name)) == 0) {
+    if (proc_name(pid, name, sizeof(name)) > 0) {
         NSString *nameStr = @(name);
         return [nameStr length] ? nameStr : nil;
     }


### PR DESCRIPTION
### Fix empty process names

[Mobile Mouse Server][1] and [CloudApp][2] both return an empty string through the `CopyProcessName` method. Returning nil instead of empty string makes Sloth go to another way of finding the correct process name.

### Fix call to proc_name

Although [not documented][3], the `proc_name` method returns 0 on failure and the legth of the process name [on success][4]. In release configuration, it is not a problem but in debug configuration Sloth was going through +procNameForPID: and returned whatever was in the uninitialized `name[1024]` buffer when the `proc_name` call failed.

[1]: https://www.mobilemouse.com
[2]: https://www.getcloudapp.com
[3]: https://developer.apple.com/documentation/kernel/1488959-proc_name
[4]: https://github.com/aosm/xnu/blob/9653931b282e653805655cc56831195d0fb162aa/libsyscall/wrappers/libproc/libproc.c#L161-L184