### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Sloth is free, open source software and has been continuously developed and main
 Sloth can also be installed via [Homebrew](https://brew.sh) (may not be latest version):
 
 ```shell
-$ brew cask install sloth
+$ brew install --cask sloth
 ```
 
 Old versions supporting macOS 10.8 and earlier can be downloaded [here](https://sveinbjorn.org/files/software/sloth/).


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103164965-30053600-4855-11eb-93d7-3a46b2a0b08c.png)
