### PR TITLE
Allow readers to use copy top clipboard button

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sloth is free, open source software and has been continuously developed and main
 Sloth can also be installed via [Homebrew](https://brew.sh) (may not be the latest version):
 
 ```shell
-$ brew install --cask sloth
+brew install --cask sloth
 ```
 
 Old versions supporting macOS 10.8 and earlier can be downloaded [here](https://sveinbjorn.org/files/software/sloth/).


### PR DESCRIPTION
There is a button to copy the `brew` command to clipboard.  Cleaned up the line to allow easy copy.